### PR TITLE
Hud should be mutable.

### DIFF
--- a/dodge-the-creeps/rust/src/main_scene.rs
+++ b/dodge-the-creeps/rust/src/main_scene.rs
@@ -82,7 +82,7 @@ impl Main {
         self.player.bind_mut().start(start_position.get_position());
         start_timer.start();
 
-        let hud = self.hud.bind_mut();
+        let mut hud = self.hud.bind_mut();
         hud.update_score(self.score);
         hud.show_message("Get Ready".into());
 


### PR DESCRIPTION
error[E0596]: cannot borrow `hud` as mutable, as it is not declared as mutable
  --> src\game.rs:73:13
   |
73 |         let hud = self.hud.bind_mut(); //mutable
   |             ^^^ not mutable
74 |         hud.update_score(self.score);
   |         --- cannot borrow as mutable
75 |         hud.show_message("Get Ready".into());
   |         --- cannot borrow as mutable
   |
help: consider changing this to be mutable
   |
73 |         let mut hud = self.hud.bind_mut(); //mutable
   |               +++