### PR TITLE
dodge-the-creeps: use native Rust signals for timers

### DIFF
--- a/dodge-the-creeps/godot/Main.tscn
+++ b/dodge-the-creeps/godot/Main.tscn
@@ -48,6 +48,4 @@ stream = ExtResource("5")
 [node name="DeathSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("6")
 
-[connection signal="timeout" from="MobTimer" to="." method="on_mob_timer_timeout"]
-[connection signal="timeout" from="ScoreTimer" to="." method="on_score_timer_timeout"]
 [connection signal="timeout" from="StartTimer" to="." method="on_start_timer_timeout"]

--- a/dodge-the-creeps/rust/src/player.rs
+++ b/dodge-the-creeps/rust/src/player.rs
@@ -1,4 +1,4 @@
-use godot::classes::{AnimatedSprite2D, Area2D, CollisionShape2D, IArea2D, Input, PhysicsBody2D};
+use godot::classes::{AnimatedSprite2D, Area2D, CollisionShape2D, IArea2D, Input};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -17,7 +17,7 @@ impl Player {
     pub fn hit();
 
     #[func]
-    fn on_player_body_entered(&mut self, _body: Gd<PhysicsBody2D>) {
+    fn on_player_body_entered(&mut self, _body: Gd<Node2D>) {
         self.base_mut().hide();
         self.signals().hit().emit();
 
@@ -55,6 +55,11 @@ impl IArea2D for Player {
         let viewport = self.base().get_viewport_rect();
         self.screen_size = viewport.size;
         self.base_mut().hide();
+
+        // Signal setup
+        self.signals()
+            .body_entered()
+            .connect_self(Self::on_player_body_entered);
     }
 
     // `delta` can be f32 or f64; #[godot_api] macro converts transparently.


### PR DESCRIPTION
With the advent of https://github.com/godot-rust/gdext/pull/1134, we can now connect all signals in Rust.

One signal, `StartTimer.timeout`, is still kept in the Editor UI for demonstration purpose.

There is another change: `_body: Gd<PhysicsBody2D>` now needs to be `_body: Gd<Node2D>` to match the declared Godot signature. This is slightly less type-safe, but we're now guaranteed that no error can occur during parameter passing.