### PR TITLE
Update MacOs runner from MacOs-13 to MacOs-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           # macOS
 
           - name: macos-x86
-            os: macos-13
+            os: macos-15
             artifact-name: macos-x86-nightly
             godot-binary: godot.macos.editor.dev.x86_64
 


### PR DESCRIPTION
MacOs-13 image for github actions premiered in 2023, while MacOs-15 is available since June 2024 https://github.com/github/roadmap/issues/986. 

We recently had issues with one of our jobs: https://github.com/godot-rust/demo-projects/actions/runs/15544817340/job/43763899820 thus upgrade won't hurt :shrug:.