### PR TITLE
Add retry to running demo projects for macOs platforms in CI

### DIFF
--- a/.github/other/retry.sh
+++ b/.github/other/retry.sh
@@ -15,7 +15,8 @@ for ((attempt=0; attempt<limit; attempt++)); do
     if "$@"; then
         # Command succeeded, exit the loop
         echo "Done."
-        break
+        # Exit with success status code.
+        exit 0
     fi
 
     # Calculate the sleep duration using the retry interval from the array
@@ -26,3 +27,7 @@ for ((attempt=0; attempt<limit; attempt++)); do
     echo "Retry #$attempt in $sleepDuration seconds..."
     sleep "$sleepDuration"
 done
+
+echo "Failed to execute command '$1'."
+# Exit with an error code.
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,15 +151,20 @@ jobs:
         include:
           # macOS
 
+          # macOS builds fail semi-randomly with an `libc++abi: Pure virtual function called!` error.
+          # For now on run them with retry; resort to compiling only if it won't be enough (i.e. first time when it will fail three times in the row).
+          # See: https://github.com/godot-rust/demo-projects/issues/12
           - name: macos-x86
             os: macos-13
             artifact-name: macos-x86-nightly
             godot-binary: godot.macos.editor.dev.x86_64
+            retry: true
 
           - name: macos-arm
             os: macos-latest
             artifact-name: macos-arm-nightly
             godot-binary: godot.macos.editor.dev.arm64
+            retry: true
 
           # Windows
 
@@ -214,17 +219,25 @@ jobs:
         run: cargo build --release ${{ matrix.rust-extra-args }}
 
       - name: "Run examples for short time"
+        env:
+          RETRY: ${{ matrix.retry }}
         run: |
           # Enable extended globbing to allow pattern exclusion.
           shopt -s extglob
 
           # Match all directories/files except `target` and any starting with `.`.
           files='!(target|.*)/'
-
+          if [[ $RETRY == "true" ]]; then
+            # macOS – retry running demo projects several times on fail.
+            echo "Running examples with retry"
+            RETRY_CMD="./.github/other/retry.sh"
+          else
+            RETRY_CMD=""
+          fi
           # List all folders in current directory. Don't quote $files variable.
           for demo in $files; do
             # Strip trailing '/' from folder name.
-          	./.github/other/check-example.sh "${demo%/}"
+            $RETRY_CMD ./.github/other/check-example.sh "${demo%/}"
           done
 
 


### PR DESCRIPTION
# What does this PR solve?

Stops running examples on macOS platforms which fail semi-randomly for unknown reason, see: https://github.com/godot-rust/demo-projects/issues/12. We weren't able to find the cause for two months.

# What was the problem extacly?

Our examples run sometimes do fail with an `libc++abi: Pure virtual function called!` error. Nobody knows what extacly causes it, thus the band-aids.

<details>
<summary> outdated description </summary>

# What does this PR solve?

In practice, nothing, it just piles more workarounds on top of each other. According to the latest godot poll https://docs.google.com/forms/d/e/1FAIpQLScKWGJoLEeNW1qrsDfZRfk7gHultapacH5ZhQmo9XRZADW1IQ/viewanalytics 30% of all the Mac users are still using intel CPUs (see question: _What type of Mac do you use? (Optional: only if you are using Mac)_) so removing it completely from the pipeline would be way too silly.

This PR introduces new variable in run matrix - `failable` - which tries to run example three times. Additionally `continue-on-error` should make whole pipeline pass even if `failable` job fails. Better than nothing, eh?

<img width="1612" height="430" alt="image" src="https://github.com/user-attachments/assets/21737501-af35-4f64-abe6-48d43994dee8" />
</details>