### PR TITLE
Add Retry to all demo projects launches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
             os: windows-latest
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
+            retry: true
 
           # Linux
 
@@ -179,11 +180,13 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
+            retry: true
 
           - name: linux-4.5
             os: ubuntu-22.04
             artifact-name: linux-4.5
             godot-binary: godot.linuxbsd.editor.dev.x86_64
+            retry: true
 
           # Deliberately don't include:
           #
@@ -228,7 +231,7 @@ jobs:
           # Match all directories/files except `target` and any starting with `.`.
           files='!(target|.*)/'
           if [[ $RETRY == "true" ]]; then
-            # macOS – retry running demo projects several times on fail.
+            # Retry running demo projects several times on fail.
             echo "Running examples with retry"
             RETRY_CMD="./.github/other/retry.sh"
           else


### PR DESCRIPTION
For some reason gathering docs fails for one of our demos with following error:

```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.5.stable.custom_build (876b290332ec6f2e6d173d08162a02aa7e6ca46d)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x42520) [0x7f313b042520] (??:0)
[2] HashMap<String, DocData::ClassDoc, HashMapHasherDefault, HashMapComparatorDefault<String>, DefaultTypedAllocator<HashMapElement<String, DocData::ClassDoc> > >::operator[](String const&) (/home/runner/work/godot4-nightly/godot4-nightly/core/templates/hash_map.h:554)
[3] DocTools::generate(BitField<DocTools::GenerateFlags>) (/home/runner/work/godot4-nightly/godot4-nightly/editor/doc/doc_tools.cpp:432)
[4] EditorHelp::_gen_extensions_docs() (/home/runner/work/godot4-nightly/godot4-nightly/editor/doc/editor_help.cpp:3093)
[5] void call_with_variant_args_static<>(void (*)(), Variant const**, Callable::CallError&, IndexSequence<>) (/home/runner/work/godot4-nightly/godot4-nightly/core/variant/binder_common.h:698)
[6] void call_with_variant_args_static<>(void (*)(), Variant const**, int, Callable::CallError&) (/home/runner/work/godot4-nightly/godot4-nightly/core/variant/binder_common.h:764)
[7] CallableCustomStaticMethodPointer<void>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/runner/work/godot4-nightly/godot4-nightly/core/object/callable_method_pointer.h:249)
[8] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/runner/work/godot4-nightly/godot4-nightly/core/variant/callable.cpp:57)
[9] CallQueue::_call_function(Callable const&, Variant const*, int, bool) (/home/runner/work/godot4-nightly/godot4-nightly/core/object/message_queue.cpp:221)
[10] CallQueue::flush() (/home/runner/work/godot4-nightly/godot4-nightly/core/object/message_queue.cpp:270)
[11] Main::cleanup(bool) (/home/runner/work/godot4-nightly/godot4-nightly/main/main.cpp:4984)
[12] /home/runner/work/_temp/godot_bin/godot.linuxbsd.editor.dev.x86_64(main+0x1b0) [0x55e9afa0be89] (/home/runner/work/godot4-nightly/godot4-nightly/platform/linuxbsd/godot_linuxbsd.cpp:91)
[13] /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f313b029d90] (??:0)
[14] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7f313b029e40] (??:0)
[15] /home/runner/work/_temp/godot_bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x55e9afa0bc15] (??:?)
-- END OF C++ BACKTRACE --
================================================================
```

https://github.com/godot-rust/demo-projects/actions/runs/18399141190/job/52424270787?pr=10

It also fails for MacOs, but for some reason is able to succeed on the second retry (example: https://github.com/godot-rust/demo-projects/actions/runs/18399141190/job/52424270783?pr=10).