### PR TITLE
Update demo projects and remove macOS x86 (Intel) from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,12 +154,6 @@ jobs:
           # macOS builds fail semi-randomly with an `libc++abi: Pure virtual function called!` error.
           # For now on run them with retry; resort to compiling only if it won't be enough (i.e. first time when it will fail three times in the row).
           # See: https://github.com/godot-rust/demo-projects/issues/12
-          - name: macos-x86
-            os: macos-13
-            artifact-name: macos-x86-nightly
-            godot-binary: godot.macos.editor.dev.x86_64
-            retry: true
-
           - name: macos-arm
             os: macos-latest
             artifact-name: macos-arm-nightly

--- a/dodge-the-creeps/rust/Cargo.toml
+++ b/dodge-the-creeps/rust/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rand = "0.8"
-godot = { git = "https://github.com/godot-rust/gdext.git" }
+godot = { git = "https://github.com/godot-rust/gdext.git", features = ["register-docs"]}
 # For Wasm, feature "experimental-wasm" can be added, but this is already done in build-wasm.sh script.
 

--- a/net-pong/rust/Cargo.toml
+++ b/net-pong/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [dependencies]
-godot = {git = "https://github.com/godot-rust/gdext.git"}
+godot = {git = "https://github.com/godot-rust/gdext.git", features = ["register-docs"]}
 
 [lib]
 crate-type = ["cdylib"] # Compile this crate to a dynamic C library.

--- a/net-pong/rust/src/paddle.rs
+++ b/net-pong/rust/src/paddle.rs
@@ -38,7 +38,7 @@ impl IArea2D for Paddle {
             });
     }
 
-    fn process(&mut self, delta: f64) {
+    fn process(&mut self, delta: f32) {
         if self.base().is_multiplayer_authority() {
             let input = Input::singleton();
             self.motion = input.get_axis("move_up", "move_down");
@@ -57,7 +57,7 @@ impl IArea2D for Paddle {
             self.you_label.hide();
         }
 
-        let translation = Vector2::new(0.0, self.motion * delta as f32);
+        let translation = Vector2::new(0.0, self.motion * delta);
 
         self.base_mut().translate(translation);
 

--- a/squash-the-creeps/rust/src/player.rs
+++ b/squash-the-creeps/rust/src/player.rs
@@ -55,7 +55,7 @@ impl ICharacterBody3D for Player {
             let mut pivot = self.base_mut().get_node_as::<Node3D>("Pivot");
 
             // Setting the basis property will affect the rotation of the node.
-            pivot.set_basis(Basis::looking_at(-direction, Vector3::UP, true));
+            pivot.set_basis(Basis::looking_at(-direction));
             self.base()
                 .get_node_as::<AnimationPlayer>("AnimationPlayer")
                 .set_speed_scale(4.0);


### PR DESCRIPTION
- Update demo projects after recent changes in API (`Basis::looking_at`)
- Remove runners for macOS x86 (Intel) architecture which are being phased out by GitHub.