### PR TITLE
dodge-the-creeps: use Array::pick_random for mob animation selection

### DIFF
--- a/dodge-the-creeps/rust/src/mob.rs
+++ b/dodge-the-creeps/rust/src/mob.rs
@@ -1,6 +1,5 @@
 use godot::classes::{AnimatedSprite2D, IRigidBody2D, RigidBody2D};
 use godot::prelude::*;
-use rand::seq::SliceRandom;
 
 #[derive(GodotClass)]
 #[class(base=RigidBody2D)]
@@ -42,10 +41,8 @@ impl IRigidBody2D for Mob {
         sprite.play();
         let anim_names = sprite.get_sprite_frames().unwrap().get_animation_names();
 
-        // TODO use pick_random() once implemented
-        let anim_names = anim_names.to_vec();
-        let mut rng = rand::thread_rng();
-        let animation_name = anim_names.choose(&mut rng).unwrap();
+        let anim_names = anim_names.to_typed_array();
+        let animation_name = anim_names.pick_random().unwrap();
 
         sprite.set_animation(animation_name.arg());
     }


### PR DESCRIPTION
resolve the TODO by using `Array::pick_random()` now that it’s available
