### PR TITLE
Update net pong to use new RPC api

### DIFF
--- a/net-pong/godot/ball.tscn
+++ b/net-pong/godot/ball.tscn
@@ -1,14 +1,14 @@
-[gd_scene load_steps=3 format=3 uid="uid://bjmldn1x3lpa"]
+[gd_scene format=3 uid="uid://bjmldn1x3lpa"]
 
-[ext_resource type="Texture2D" uid="uid://i1imfdcn7ui" path="res://ball.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://dc80h5wew8ulk" path="res://ball.png" id="2"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 5.11969
 
-[node name="Ball" type="Ball"]
+[node name="Ball" type="Ball" unique_id=1838185822]
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=1601709826]
 texture = ExtResource("2")
 
-[node name="Shape3D" type="CollisionShape2D" parent="."]
+[node name="Shape3D" type="CollisionShape2D" parent="." unique_id=1051498162]
 shape = SubResource("1")

--- a/net-pong/godot/lobby.tscn
+++ b/net-pong/godot/lobby.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://f85s2avde6r4"]
 
-[node name="Lobby" type="Control"]
+[node name="Lobby" type="Control" unique_id=240206270]
 layout_mode = 3
 anchors_preset = 8
 anchor_left = 0.5
@@ -16,7 +16,7 @@ grow_vertical = 2
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
-[node name="Title" type="Label" parent="."]
+[node name="Title" type="Label" parent="." unique_id=2039769192]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -36,7 +36,7 @@ text = "Multiplayer Pong"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="LobbyPanel" type="Lobby" parent="." node_paths=PackedStringArray("address", "host_button", "join_button", "status_ok", "status_fail", "port_forward_label", "find_public_ip_button")]
+[node name="LobbyPanel" type="Lobby" parent="." unique_id=1250530587 node_paths=PackedStringArray("address", "host_button", "join_button", "status_ok", "status_fail", "port_forward_label", "find_public_ip_button")]
 address = NodePath("Address")
 host_button = NodePath("HostButton")
 join_button = NodePath("JoinButton")
@@ -59,7 +59,7 @@ grow_vertical = 2
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
-[node name="AddressLabel" type="Label" parent="LobbyPanel"]
+[node name="AddressLabel" type="Label" parent="LobbyPanel" unique_id=1083040553]
 layout_mode = 0
 offset_left = 10.0
 offset_top = 6.0
@@ -69,7 +69,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "Address:"
 
-[node name="Address" type="LineEdit" parent="LobbyPanel"]
+[node name="Address" type="LineEdit" parent="LobbyPanel" unique_id=188993081]
 layout_mode = 0
 offset_left = 10.0
 offset_top = 37.0
@@ -79,7 +79,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 text = "127.0.0.1"
 
-[node name="HostButton" type="Button" parent="LobbyPanel"]
+[node name="HostButton" type="Button" parent="LobbyPanel" unique_id=1074064387]
 layout_mode = 0
 offset_left = 10.0
 offset_top = 76.0
@@ -89,7 +89,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 text = "Host"
 
-[node name="JoinButton" type="Button" parent="LobbyPanel"]
+[node name="JoinButton" type="Button" parent="LobbyPanel" unique_id=1019011179]
 layout_mode = 0
 offset_left = 130.0
 offset_top = 76.0
@@ -99,7 +99,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 text = "Join"
 
-[node name="StatusOk" type="Label" parent="LobbyPanel"]
+[node name="StatusOk" type="Label" parent="LobbyPanel" unique_id=1633483328]
 layout_mode = 0
 offset_left = 10.0
 offset_top = 114.0
@@ -109,7 +109,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 horizontal_alignment = 1
 
-[node name="StatusFail" type="Label" parent="LobbyPanel"]
+[node name="StatusFail" type="Label" parent="LobbyPanel" unique_id=933125461]
 modulate = Color(1, 0.427451, 0.345098, 1)
 layout_mode = 0
 offset_left = 10.0
@@ -120,7 +120,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 horizontal_alignment = 1
 
-[node name="PortForward" type="Label" parent="LobbyPanel"]
+[node name="PortForward" type="Label" parent="LobbyPanel" unique_id=623464281]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -138,7 +138,7 @@ text = "If you want non-LAN clients to connect,
 make sure the port 8910 in UDP
 is forwarded on your router."
 
-[node name="FindPublicIP" type="LinkButton" parent="LobbyPanel"]
+[node name="FindPublicIP" type="LinkButton" parent="LobbyPanel" unique_id=468477990]
 visible = false
 layout_mode = 1
 anchors_preset = 8

--- a/net-pong/godot/paddle.tscn
+++ b/net-pong/godot/paddle.tscn
@@ -1,21 +1,21 @@
-[gd_scene load_steps=3 format=3 uid="uid://cpw46256eirwq"]
+[gd_scene format=3 uid="uid://cpw46256eirwq"]
 
-[ext_resource type="Texture2D" uid="uid://bjw2yb853klh2" path="res://paddle.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://faaa5fcbbpmh" path="res://paddle.png" id="2"]
 
 [sub_resource type="CapsuleShape2D" id="1"]
 radius = 4.78568
 height = 23.6064
 
-[node name="Paddle" type="Paddle" node_paths=PackedStringArray("you_label")]
+[node name="Paddle" type="Paddle" unique_id=1998518565 node_paths=PackedStringArray("you_label")]
 you_label = NodePath("You")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=974349175]
 texture = ExtResource("2")
 
-[node name="Shape3D" type="CollisionShape2D" parent="."]
+[node name="Shape3D" type="CollisionShape2D" parent="." unique_id=818542247]
 shape = SubResource("1")
 
-[node name="You" type="Label" parent="."]
+[node name="You" type="Label" parent="." unique_id=717389319]
 offset_left = -26.0
 offset_top = -33.0
 offset_right = 27.0

--- a/net-pong/godot/pong.tscn
+++ b/net-pong/godot/pong.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://bafoh1ief0147"]
+[gd_scene format=3 uid="uid://bafoh1ief0147"]
 
 [ext_resource type="Texture2D" uid="uid://bnx1f3bsxpy7y" path="res://separator.png" id="2"]
 [ext_resource type="PackedScene" uid="uid://cpw46256eirwq" path="res://paddle.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://bjmldn1x3lpa" path="res://ball.tscn" id="4"]
 
-[node name="Pong" type="Pong" node_paths=PackedStringArray("host_player", "client_player", "score_left_node", "score_right_node", "winner_left", "winner_right", "exit_game", "ball")]
+[node name="Pong" type="Pong" unique_id=550431825 node_paths=PackedStringArray("host_player", "client_player", "score_left_node", "score_right_node", "winner_left", "winner_right", "exit_game", "ball")]
 host_player = NodePath("Player1")
 client_player = NodePath("Player2")
 score_left_node = NodePath("ScoreLeft")
@@ -14,30 +14,30 @@ winner_right = NodePath("WinnerRight")
 exit_game = NodePath("ExitGame")
 ball = NodePath("Ball")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=1028565857]
 offset_right = 640.0
 offset_bottom = 400.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.141176, 0.152941, 0.164706, 1)
 
-[node name="Separator" type="Sprite2D" parent="."]
+[node name="Separator" type="Sprite2D" parent="." unique_id=652289330]
 position = Vector2(320, 200)
 texture = ExtResource("2")
 
-[node name="Player1" parent="." instance=ExtResource("3")]
+[node name="Player1" parent="." unique_id=1135436356 instance=ExtResource("3")]
 left = true
 modulate = Color(0, 1, 1, 1)
 position = Vector2(32.49, 188.622)
 
-[node name="Player2" parent="." instance=ExtResource("3")]
+[node name="Player2" parent="." unique_id=788160046 instance=ExtResource("3")]
 modulate = Color(1, 0, 1, 1)
 position = Vector2(608.88, 188.622)
 
-[node name="Ball" parent="." instance=ExtResource("4")]
+[node name="Ball" parent="." unique_id=92772472 instance=ExtResource("4")]
 position = Vector2(320.387, 189.525)
 
-[node name="ScoreLeft" type="Label" parent="."]
+[node name="ScoreLeft" type="Label" parent="." unique_id=2033881509]
 offset_left = 240.0
 offset_top = 10.0
 offset_right = 280.0
@@ -46,7 +46,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "0"
 
-[node name="ScoreRight" type="Label" parent="."]
+[node name="ScoreRight" type="Label" parent="." unique_id=1424664919]
 offset_left = 360.0
 offset_top = 10.0
 offset_right = 400.0
@@ -55,7 +55,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "0"
 
-[node name="WinnerLeft" type="Label" parent="."]
+[node name="WinnerLeft" type="Label" parent="." unique_id=297977857]
 visible = false
 offset_left = 190.0
 offset_top = 170.0
@@ -65,7 +65,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "The Winner!"
 
-[node name="WinnerRight" type="Label" parent="."]
+[node name="WinnerRight" type="Label" parent="." unique_id=162158270]
 visible = false
 offset_left = 380.0
 offset_top = 170.0
@@ -75,7 +75,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "The Winner!"
 
-[node name="ExitGame" type="Button" parent="."]
+[node name="ExitGame" type="Button" parent="." unique_id=1541802082]
 visible = false
 offset_left = 280.0
 offset_top = 340.0
@@ -85,7 +85,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 text = "Exit Game"
 
-[node name="Camera2D" type="Camera2D" parent="."]
+[node name="Camera2D" type="Camera2D" parent="." unique_id=824416612]
 offset = Vector2(320, 200)
 
 [editable path="Player1"]

--- a/net-pong/godot/project.godot
+++ b/net-pong/godot/project.godot
@@ -8,11 +8,15 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="Multiplayer Pong"
 run/main_scene="uid://f85s2avde6r4"
-config/features=PackedStringArray("4.5", "GL Compatibility")
+config/features=PackedStringArray("4.7", "GL Compatibility")
 config/icon="uid://71q6yteydysw"
 
 [display]

--- a/net-pong/rust/Cargo.toml
+++ b/net-pong/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [dependencies]
-godot = {git = "https://github.com/godot-rust/gdext.git", features = ["register-docs"]}
+godot = {git = "https://github.com/godot-rust/gdext.git", branch = "bugfix/rpc-panics", features = ["register-docs"]}
 
 [lib]
 crate-type = ["cdylib"] # Compile this crate to a dynamic C library.

--- a/net-pong/rust/Cargo.toml
+++ b/net-pong/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [dependencies]
-godot = {git = "https://github.com/godot-rust/gdext.git", branch = "bugfix/rpc-panics", features = ["register-docs"]}
+godot = {git = "https://github.com/godot-rust/gdext.git", features = ["register-docs"]}
 
 [lib]
 crate-type = ["cdylib"] # Compile this crate to a dynamic C library.

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -86,10 +86,7 @@ impl Ball {
     #[rpc(any_peer, call_local)]
     fn reset_ball(&mut self, for_left: bool) {
         let screen_center = self.base().get_viewport_rect().size / 2.0;
-        // drop base mut to avoid panics
-        {
-            self.base_mut().set_position(screen_center);
-        }
+        self.base_mut().set_position(screen_center);
         if for_left {
             self.direction = Vector2::LEFT;
         } else {

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -46,7 +46,13 @@ impl IArea2D for Ball {
             // fast. Otherwise, the ball might be out in the other
             // player's screen but not this one.
             if ball_pos.x < 0.0 {
-                let _ = parent.rpcs().update_score(false).call();
+                // When calling the parent rpc, we have to create a base_mut() guard for the ball
+                // This is because the update_score() RPC calls an RPC back to Ball inside of it
+                // And, if we don't have a guard set up, that could cause a panic since we are doing a mutable reborrow
+                {
+                    let _guard = self.base_mut();
+                    let _ = parent.rpcs().update_score(false).call();
+                }
                 godot_print!("Reset ball right");
                 if let Err(e) = self.rpcs().reset_ball(false).call() {
                     godot_print!("Rpc error {e}");
@@ -59,7 +65,10 @@ impl IArea2D for Ball {
             // is going fast. Otherwise, the ball might be out in the
             // other player's screen but not this one.
             if ball_pos.x > screen_size.x {
-                let _ = parent.rpcs().update_score(true).call();
+                {
+                    let _guard = self.base_mut();
+                    let _ = parent.rpcs().update_score(true).call();
+                }
                 godot_print!("Reset ball left");
                 if let Err(e) = self.rpcs().reset_ball(true).call() {
                     godot_print!("Rpc error {e}");

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -38,19 +38,16 @@ impl IArea2D for Ball {
             self.direction.y = -self.direction.y;
         }
 
-        let mut parent = self.base().get_parent().unwrap().cast::<Pong>();
-        // Use base_mut() to allow for reentrancy – required if a game stops, and we need to reset our ball.
-        let mut guard = self.base_mut();
-        if guard.is_multiplayer_authority() {
+        let parent = self.base().get_parent().unwrap().cast::<Pong>();
+        if self.base().is_multiplayer_authority() {
             // Only the master will decide when the ball is out on
             // the left side (its own side). This makes the game
             // playable even if latency is high and ball is going
             // fast. Otherwise, the ball might be out in the other
             // player's screen but not this one.
             if ball_pos.x < 0.0 {
-                let args = vslice![false];
-                parent.rpc("update_score", args);
-                guard.rpc("reset_ball", args);
+                let _ = parent.rpcs().update_score(false).call();
+                let _ = self.rpcs().reset_ball(false).call();
             }
         } else {
             // Only the puppet will decide when the ball is out on
@@ -59,9 +56,8 @@ impl IArea2D for Ball {
             // is going fast. Otherwise, the ball might be out in the
             // other player's screen but not this one.
             if ball_pos.x > screen_size.x {
-                let args = vslice![true];
-                parent.rpc("update_score", args);
-                guard.rpc("reset_ball", args);
+                let _ = parent.rpcs().update_score(true).call();
+                let _ = self.rpcs().reset_ball(true).call();
             }
         }
     }
@@ -90,7 +86,10 @@ impl Ball {
     #[rpc(any_peer, call_local)]
     fn reset_ball(&mut self, for_left: bool) {
         let screen_center = self.base().get_viewport_rect().size / 2.0;
-        self.base_mut().set_position(screen_center);
+        // drop base mut to avoid panics
+        {
+            self.base_mut().set_position(screen_center);
+        }
         if for_left {
             self.direction = Vector2::LEFT;
         } else {

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -47,7 +47,11 @@ impl IArea2D for Ball {
             // player's screen but not this one.
             if ball_pos.x < 0.0 {
                 let _ = parent.rpcs().update_score(false).call();
-                let _ = self.rpcs().reset_ball(false).call();
+                godot_print!("Reset ball right");
+                match self.rpcs().reset_ball(false).call() {
+                    Ok(()) => todo!(),
+                    Err(e) => godot_print!("Rpc error {e}"),
+                }
             }
         } else {
             // Only the puppet will decide when the ball is out on
@@ -57,7 +61,11 @@ impl IArea2D for Ball {
             // other player's screen but not this one.
             if ball_pos.x > screen_size.x {
                 let _ = parent.rpcs().update_score(true).call();
-                let _ = self.rpcs().reset_ball(true).call();
+                godot_print!("Reset ball left");
+                match self.rpcs().reset_ball(true).call() {
+                    Ok(()) => todo!(),
+                    Err(e) => godot_print!("Rpc error {e}"),
+                }
             }
         }
     }
@@ -86,7 +94,9 @@ impl Ball {
     #[rpc(any_peer, call_local)]
     fn reset_ball(&mut self, for_left: bool) {
         let screen_center = self.base().get_viewport_rect().size / 2.0;
+        godot_print!("Modifying position");
         self.base_mut().set_position(screen_center);
+        godot_print!("Position modified");
         if for_left {
             self.direction = Vector2::LEFT;
         } else {

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -87,6 +87,7 @@ impl Ball {
     #[rpc(any_peer, call_local)]
     fn stop(&mut self) {
         self.stopped = true;
+        godot_print!("Ball stopped");
     }
 
     #[rpc(any_peer, call_local)]

--- a/net-pong/rust/src/ball.rs
+++ b/net-pong/rust/src/ball.rs
@@ -48,9 +48,8 @@ impl IArea2D for Ball {
             if ball_pos.x < 0.0 {
                 let _ = parent.rpcs().update_score(false).call();
                 godot_print!("Reset ball right");
-                match self.rpcs().reset_ball(false).call() {
-                    Ok(()) => todo!(),
-                    Err(e) => godot_print!("Rpc error {e}"),
+                if let Err(e) = self.rpcs().reset_ball(false).call() {
+                    godot_print!("Rpc error {e}");
                 }
             }
         } else {
@@ -62,9 +61,8 @@ impl IArea2D for Ball {
             if ball_pos.x > screen_size.x {
                 let _ = parent.rpcs().update_score(true).call();
                 godot_print!("Reset ball left");
-                match self.rpcs().reset_ball(true).call() {
-                    Ok(()) => todo!(),
-                    Err(e) => godot_print!("Rpc error {e}"),
+                if let Err(e) = self.rpcs().reset_ball(true).call() {
+                    godot_print!("Rpc error {e}");
                 }
             }
         }
@@ -103,5 +101,6 @@ impl Ball {
             self.direction = Vector2::RIGHT;
         }
         self.speed = DEFAULT_SPEED;
+        godot_print!("Reset Ball RPC finished");
     }
 }

--- a/net-pong/rust/src/paddle.rs
+++ b/net-pong/rust/src/paddle.rs
@@ -17,7 +17,19 @@ struct Paddle {
     base: Base<Area2D>,
 }
 
+#[godot_api]
+impl Paddle {
+    #[rpc(unreliable)]
+    fn set_pos_and_motion(&mut self, pos: Vector2, motion: f32) {
+        self.base_mut().set_position(pos);
+        self.motion = motion;
+    }
+}
+
 use godot::classes::IArea2D;
+use godot::obj::WithUserRpcs;
+
+use crate::ball::Ball;
 
 #[godot_api]
 impl IArea2D for Paddle {
@@ -25,15 +37,12 @@ impl IArea2D for Paddle {
         // bounce signal is emitted when the ball enters the paddle area.
         self.signals()
             .area_entered()
-            .connect_self(|this: &mut Self, mut area: Gd<Area2D>| {
-                if this.base().is_multiplayer_authority() {
+            .connect_self(|this: &mut Self, area: Gd<Area2D>| {
+                if let Ok(ball) = area.try_cast::<Ball>()
+                    && this.base().is_multiplayer_authority()
+                {
                     // Set a random direction for the ball to go in
-                    // Note: all RPCs consume their arguments as Variant
-                    // this is a limitation of godot-rust
-                    // we currently don't have a way to statically type RPCs the way we do for signals
-                    // so we have to use a variant array slice and convert manually
-                    let args = vslice![this.left, randf()];
-                    area.rpc("bounce", args);
+                    let _ = ball.rpcs().bounce(this.left, randf() as f32).call();
                 }
             });
     }
@@ -51,8 +60,9 @@ impl IArea2D for Paddle {
 
             // Using unreliable to make sure position is updated as fast
             // as possible, even if one of the calls is dropped.
-            let args = vslice![self.base().get_position(), self.motion];
-            self.base_mut().rpc("set_pos_and_motion", args);
+            let position = self.base().get_position();
+            let motion = self.motion;
+            let _ = self.rpcs().set_pos_and_motion(position, motion).call();
         } else if !self.you_hidden {
             self.you_label.hide();
         }
@@ -68,14 +78,5 @@ impl IArea2D for Paddle {
             position.x,
             position.y.clamp(16.0, screen_size_y - 16.0),
         ));
-    }
-}
-
-#[godot_api]
-impl Paddle {
-    #[rpc(unreliable)]
-    fn set_pos_and_motion(&mut self, pos: Vector2, motion: f32) {
-        self.base_mut().set_position(pos);
-        self.motion = motion;
     }
 }

--- a/net-pong/rust/src/pong.rs
+++ b/net-pong/rust/src/pong.rs
@@ -25,6 +25,9 @@ pub struct Pong {
     exit_game: OnEditor<Gd<Button>>,
     #[export]
     ball: OnEditor<Gd<Ball>>,
+    #[export]
+    #[init(val = SCORE_TO_WIN)]
+    score_to_win: i32,
     base: Base<Node2D>,
 }
 
@@ -70,10 +73,10 @@ impl Pong {
         }
 
         let mut game_ended = false;
-        if self.score_left == SCORE_TO_WIN {
+        if self.score_left == self.score_to_win {
             self.winner_left.show();
             game_ended = true;
-        } else if self.score_right == SCORE_TO_WIN {
+        } else if self.score_right == self.score_to_win {
             self.winner_right.show();
             game_ended = true;
         }

--- a/net-pong/rust/src/pong.rs
+++ b/net-pong/rust/src/pong.rs
@@ -80,7 +80,7 @@ impl Pong {
 
         if game_ended {
             self.exit_game.show();
-            self.ball.rpc("stop", &[]);
+            let _ = self.ball.rpcs().stop().call();
         }
     }
 


### PR DESCRIPTION
mostly works but theres a weird panic that gets repeated over and over currently when ball gets stopped and reset
```
E 0:00:15:098   godot_core::private::set_gdext_hook::{{closure}}: [panic C:\Users\sraya\.cargo\git\checkouts\gdext-067f4b88e7bd088f\45e4711\godot-core\src\storage\mod.rs:38]
  Gd<T>::bind_mut() failed, already bound; T = net_pong::ball::Ball.
    Make sure to use `self.base_mut()` instead of `self.to_gd()` when possible.
    Details: cannot borrow while accessible mutable borrow exists.
  in Ball::reset_ball()
  <C++ Source>  C:\Users\sraya\.cargo\git\checkouts\gdext-067f4b88e7bd088f\45e4711\godot-core\src\private.rs:333 @ godot_core::private::set_gdext_hook::{{closure}}()
E 0:00:15:103   rpcp: rpc() aborted in local call:  - 'Ball::reset_ball': .
  <C++ Source>  modules/multiplayer/scene_rpc_interface.cpp:513 @ rpcp()
```